### PR TITLE
/list feat(feature/pace-5): added displayName for Collibra databases

### DIFF
--- a/app/src/main/kotlin/com/getstrm/pace/catalogs/Collibra.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/catalogs/Collibra.kt
@@ -19,13 +19,12 @@ class CollibraCatalog(config: CatalogConfiguration) : DataCatalog(config) {
 
     override suspend fun listDatabases(): List<DataCatalog.Database> =
         listPhysicalAssets(AssetTypes.DATABASE).map {
-            Database(this, it.id, it.getDataSourceType())
+            Database(this, it.id.toString(), it.getDataSourceType(), it.displayName?:"")
         }
 
-    class Database(override val catalog: CollibraCatalog, id: String, dbType: String) :
-        DataCatalog.Database(catalog, id, dbType) {
-        constructor(catalog: CollibraCatalog, id: Any, dbType: String) : this(catalog, id.toString(), dbType)
-
+    class Database(override val catalog: CollibraCatalog, id: String, dbType: String, displayName: String) :
+        DataCatalog.Database(catalog, id, dbType, displayName) {
+            
         override suspend fun getSchemas(): List<DataCatalog.Schema> {
             val assets = catalog.client.query(ListSchemaIdsQuery(id)).execute().data!!.assets!!.filterNotNull()
                 .flatMap { schema ->


### PR DESCRIPTION
Very simple fix.
```
pace list databases --catalog COLLIBRA-testdrive
databases:
- catalog:
    id: COLLIBRA-testdrive
    type: COLLIBRA
  display_name: DWH_PROD
  id: 8665f375-e08a-4810-add6-7af490f748ad
  type: Snowflake
- catalog:
    id: COLLIBRA-testdrive
    type: COLLIBRA
  display_name: test-drive-329411
  id: 99379294-6e87-4e26-9f09-21c6bf86d415
  type: CData JDBC Driver for Google BigQuery 2021
- catalog:
    id: COLLIBRA-testdrive
    type: COLLIBRA
  display_name: DC22_PROTECT_TESTDRIVE
  id: b6e043a7-88f1-42ee-8e81-0fdc1c96f471
  type: Snowflake

```