### PR TITLE
Feature/pace 57

### DIFF
--- a/app/src/main/kotlin/com/getstrm/pace/catalogs/OpenDataDiscovery.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/catalogs/OpenDataDiscovery.kt
@@ -3,6 +3,7 @@ package com.getstrm.pace.catalogs
 import build.buf.gen.getstrm.pace.api.entities.v1alpha.DataPolicy
 import com.getstrm.pace.config.CatalogConfiguration
 import com.getstrm.pace.util.normalizeType
+import okhttp3.internal.notifyAll
 import org.opendatadiscovery.generated.api.DataSetApi
 import org.opendatadiscovery.generated.api.DataSourceApi
 import org.opendatadiscovery.generated.api.SearchApi
@@ -100,10 +101,10 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
                         .build().normalizeType()
                 },
             )
-
-            policyBuilder.metadataBuilder.title = schema.database.displayName
-            policyBuilder.metadataBuilder.description = schema.database.dbType
-
+            with(policyBuilder.metadataBuilder){
+                title=name
+                description = schema.database.displayName
+            }
             return policyBuilder.build()
         }
     }
@@ -126,30 +127,30 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
      */
     private fun searchDataSetsInDataSource(dataSource: DataSource): SearchFacetsData =
         searchClient.search(
-        SearchFormData(
-            query = "",
-            filters = SearchFormDataFilters(
-                entityClasses = listOf(
-                    SearchFilterState(
-                        entityName = "DATA_SET",
-                        // selected means that this is included in the search results
-                        selected = true,
-                        // Not sure why the entity id is necessary, I think it
-                        // refers to the entity class id, which "should be" a static
-                        // value, in case of the entity type DATA_SET it is 1
-                        entityId = 1,
+            SearchFormData(
+                query = "",
+                filters = SearchFormDataFilters(
+                    entityClasses = listOf(
+                        SearchFilterState(
+                            entityName = "DATA_SET",
+                            // selected means that this is included in the search results
+                            selected = true,
+                            // Not sure why the entity id is necessary, I think it
+                            // refers to the entity class id, which "should be" a static
+                            // value, in case of the entity type DATA_SET it is 1
+                            entityId = 1,
+                        ),
                     ),
-                ),
-                datasources = listOf(
-                    SearchFilterState(
-                        entityName = dataSource.name,
-                        entityId = dataSource.id,
-                        selected = true,
+                    datasources = listOf(
+                        SearchFilterState(
+                            entityName = dataSource.name,
+                            entityId = dataSource.id,
+                            selected = true,
+                        )
                     )
-                )
+                ),
             ),
-        ),
-    )
+        )
 
     /**
      * recursively get all results for a given search id.

--- a/app/src/main/kotlin/com/getstrm/pace/catalogs/OpenDataDiscovery.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/catalogs/OpenDataDiscovery.kt
@@ -16,82 +16,49 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
     private val searchClient = SearchApi(configuration.serverUrl)
     private val datasetsClient = DataSetApi(configuration.serverUrl)
     private val dataSourceClient = DataSourceApi(configuration.serverUrl)
-
     private val dataSources = getAllDataSources().associateBy { it.id }
 
-    override suspend fun listDatabases(): List<Database> {
-        val searchRef = searchClient.search(
-            SearchFormData(
-                query = "",
-                filters = SearchFormDataFilters(
-                    entityClasses = listOf(
-                        SearchFilterState(
-                            entityName = "DATA_SET",
-                            // selected means that this is included in the search results
-                            selected = true,
-                            // Not sure why the entity id is necessary, I think it
-                            // refers to the entity class id, which "should be" a static
-                            // value, in case of the entity type DATA_SET it is 1
-                            entityId = 1,
-                        ),
-                    ),
-                ),
-            ),
-        )
-
-        return getAllSearchResults(searchRef.searchId).map {
-            val dataSource = dataSources[it.dataSource.id]?.name ?: "unknown"
-            Database(this, it.id.toString(), dataSource, it.externalName)
+    /**
+     * We're doing a weird workaround, where we search all datasets, and then find the data sources
+     * that contain any datasets.
+     */
+    override suspend fun listDatabases(): List<Database> =
+        dataSources.mapNotNull { (_, dataSource) ->
+            val searchId = searchDataSetsInDataSource(dataSource).searchId
+            if (searchClient.getSearchResults(searchId, 1, 1).items.isNotEmpty()) dataSource else null
+        }.map {
+            Database(this, it, it.id.toString(), it.namespace?.name ?: "", it.name)
         }
-    }
 
-    private fun getAllSearchResults(searchId: UUID, page: Int = 1, size: Int = 100): List<DataEntity> {
-        val searchResults = searchClient.getSearchResults(searchId, page, size)
-
-        return if (searchResults.items.size == size) {
-            searchResults.items + getAllSearchResults(searchId, page + 1, size)
-        } else {
-            searchResults.items
-        }
-    }
-
-    private fun getAllDataSources(page: Int = 1, size: Int = 100): List<DataSource> {
-        val dataSources = dataSourceClient.getDataSourceList(page, size)
-
-        return if (dataSources.items.size == size) {
-            dataSources.items + getAllDataSources(page + 1, size)
-        } else {
-            dataSources.items
-        }
-    }
-
-    override fun close() {
-    }
-
-    class Database(override val catalog: OpenDataDiscoveryCatalog, id: String, dbType: String, displayName: String) :
-        DataCatalog.Database(catalog, id, dbType, displayName) {
-        /** Effectively a noop, but that's because ODD's data model isn't hierachical
-         */
+    class Database(
+        override val catalog: OpenDataDiscoveryCatalog,
+        val dataSource: DataSource,
+        id: String,
+        dbType: String,
+        displayName: String
+    ) : DataCatalog.Database(catalog, id, dbType, displayName) {
         override suspend fun getSchemas(): List<Schema> {
-            return listOf(Schema(catalog, this, id, dbType.orEmpty()))
+            return listOf(Schema(catalog, this, "schema", dataSource.name))
         }
     }
 
     class Schema(
         private val catalog: OpenDataDiscoveryCatalog,
-        database: DataCatalog.Database,
+        val oddDatabase: Database,
         id: String,
         name: String,
-    ) :
-        DataCatalog.Schema(database, id, name) {
+    ) : DataCatalog.Schema(oddDatabase, id, name) {
         override suspend fun getTables(): List<DataCatalog.Table> {
-            return listOf(Table(catalog, this, id, name))
+
+            val ref = catalog.searchDataSetsInDataSource(oddDatabase.dataSource)
+            val x = catalog.getAllSearchResults(ref.searchId)
+            return x.map{Table(catalog, this, "${it.id}", it.externalName)}
         }
     }
 
+
     class Table(private val catalog: OpenDataDiscoveryCatalog, schema: DataCatalog.Schema, id: String, name: String) :
         DataCatalog.Table(schema, id, name) {
-
         private fun getAllParents(parentId: Long, fieldsById: Map<Long, DataSetField>): List<Long> {
             val parent = checkNotNull(fieldsById[parentId]) { "The parent field should exist" }
 
@@ -101,9 +68,8 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
                 listOf(parent.id)
             }
         }
-
         override suspend fun getDataPolicy(): DataPolicy? {
-            val datasetStructure = catalog.datasetsClient.getDataSetStructureLatest(schema.database.id.toLong())
+            val datasetStructure = catalog.datasetsClient.getDataSetStructureLatest(id.toLong())
             val fields = datasetStructure.fieldList
             val fieldsById = fields.associateBy { it.id }
 
@@ -131,6 +97,62 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
             policyBuilder.metadataBuilder.description = schema.database.dbType
 
             return policyBuilder.build()
+        }
+    }
+
+    private fun getAllDataSources(page: Int = 1, size: Int = 100): List<DataSource> {
+        val dataSources = dataSourceClient.getDataSourceList(page, size)
+        return if (dataSources.items.size == size) {
+            dataSources.items + getAllDataSources(page + 1, size)
+        } else {
+            dataSources.items
+        }
+    }
+
+    override fun close() {
+    }
+
+
+    /**
+     * search all the datasets in one particular dataSource.
+     */
+    private fun searchDataSetsInDataSource(dataSource: DataSource): SearchFacetsData =
+        searchClient.search(
+        SearchFormData(
+            query = "",
+            filters = SearchFormDataFilters(
+                entityClasses = listOf(
+                    SearchFilterState(
+                        entityName = "DATA_SET",
+                        // selected means that this is included in the search results
+                        selected = true,
+                        // Not sure why the entity id is necessary, I think it
+                        // refers to the entity class id, which "should be" a static
+                        // value, in case of the entity type DATA_SET it is 1
+                        entityId = 1,
+                    ),
+                ),
+                datasources = listOf(
+                    SearchFilterState(
+                        entityName = dataSource.name,
+                        entityId = dataSource.id,
+                        selected = true,
+                    )
+                )
+            ),
+        ),
+    )
+
+    /**
+     * recursively get all results for a given search id.
+     */
+    private fun getAllSearchResults(searchId: UUID, page: Int = 1, size: Int = 100): List<DataEntity> {
+        val searchResults = searchClient.getSearchResults(searchId, page, size)
+
+        return if (searchResults.items.size == size) {
+            searchResults.items + getAllSearchResults(searchId, page + 1, size)
+        } else {
+            searchResults.items
         }
     }
 }

--- a/app/src/main/kotlin/com/getstrm/pace/catalogs/OpenDataDiscovery.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/catalogs/OpenDataDiscovery.kt
@@ -3,7 +3,6 @@ package com.getstrm.pace.catalogs
 import build.buf.gen.getstrm.pace.api.entities.v1alpha.DataPolicy
 import com.getstrm.pace.config.CatalogConfiguration
 import com.getstrm.pace.util.normalizeType
-import okhttp3.internal.notifyAll
 import org.opendatadiscovery.generated.api.DataSetApi
 import org.opendatadiscovery.generated.api.DataSourceApi
 import org.opendatadiscovery.generated.api.SearchApi
@@ -25,7 +24,7 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
      * of this kind in its api.
      */
     override suspend fun listDatabases(): List<Database> =
-        dataSources.values.filter{dataSource ->
+        dataSources.values.filter { dataSource ->
             val searchId = searchDataSetsInDataSource(dataSource).searchId
             // we try for one search result on the first page, we only want to know if there are any.
             searchClient.getSearchResults(searchId, 1, 1).items.isNotEmpty()
@@ -77,6 +76,7 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
                 listOf(parent.id)
             }
         }
+
         override suspend fun getDataPolicy(): DataPolicy? {
             val datasetStructure = catalog.datasetsClient.getDataSetStructureLatest(id.toLong())
             val fields = datasetStructure.fieldList
@@ -101,8 +101,8 @@ class OpenDataDiscoveryCatalog(configuration: CatalogConfiguration) : DataCatalo
                         .build().normalizeType()
                 },
             )
-            with(policyBuilder.metadataBuilder){
-                title=name
+            with(policyBuilder.metadataBuilder) {
+                title = name
                 description = schema.database.displayName
             }
             return policyBuilder.build()

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -69,6 +69,7 @@
 * [PACE Configuration](reference/pace-configuration.md)
 * [Integrations](integrations-and-reference/integrations/README.md)
   * [Data Catalog Integrations](reference/data-catalog-integrations/README.md)
+      * [Data Catalog Specifics](reference/data-catalog-integrations/catalog-specifics.md)
   * [Processing Platform Integrations](reference/processing-platform-integrations/README.md)
     * [BigQuery](reference/processing-platform-integrations/bigquery.md)
     * [Databricks](reference/processing-platform-integrations/databricks.md)

--- a/docs/reference/data-catalog-integrations/catalog-specifics.md
+++ b/docs/reference/data-catalog-integrations/catalog-specifics.md
@@ -1,0 +1,72 @@
+# Data Catalog Specifics
+
+Much as we try to make the interaction with all Data Catalogs identical, there are some oddities.
+
+## OpenDataDiscovery
+This catalog doesn't really have a hierarchy of `database` → `schema` → `table`.
+It contains the concept of `DataSource`, but not all of these even have associated data sets (i.e. things with a schema
+that PACE can interpret).
+
+In order to provide a useful hierarchy we interpret all those Data Sources that have at least one DataSet as a `database`.
+Schemas don't really exist on OpenDataDiscovery, but we need it in the PACE hierarchy. We create one _dummy_ Schema with
+an `id` of `schema` and a name identical to the Data Source name.
+
+The tables work as expected.
+
+An example (using the OpenDataDiscovery sample data). I've used `jq` to simplify the output somewhat.
+
+### List Databases
+This list all data sources with at least one OpenDataDiscovery Data Set.
+```shell
+pace list databases --catalog odd -o json | jq -r '.databases[]|[.id,.display_name,.type]|@csv'
+"2","BookShop Data Lake","Data Lake"
+"3","BookShop Transactional","Transactional"
+"5","User Transactions","Messaging"
+"7","KDS Clickstream","Messaging"
+"8","Snowflake Sample Data","Samples"
+```
+
+### List Schemas
+There's just one schema in each `Database`, because OpenDataDiscovery doesn't have _schemas_ as such.
+```shell
+pace list schemas --catalog odd --database 3 -o json | jq -r '.schemas[]|[.id,.name]|@csv'
+"schema","BookShop Transactional"
+```
+
+### List Tables
+To list the tables (same as in any other catalog), we need the `database` and the `schema`. OpenDataDiscovery uses
+numeric entity id's, and the one for the `BookShop Transactional` postgres database is `3`. The query below shows that
+the `name` of the `schema` is identical to the `name` of the `database`.
+
+```shell
+pace list tables --catalog odd --database 3 --schema schema -o json | jq -r '.tables[]|[.id,.name,.schema.name]|@csv'
+"15","dim_publishers","BookShop Transactional"
+"14","fct_sales","BookShop Transactional"
+"13","fct_inventory","BookShop Transactional"
+"12","dim_currency","BookShop Transactional"
+"11","dim_books","BookShop Transactional"
+"10","dim_promo","BookShop Transactional"
+"9","customer_tier_sbx","BookShop Transactional"
+"8","dim_countries","BookShop Transactional"
+"7","dim_cards","BookShop Transactional"
+"6","dim_customer","BookShop Transactional"
+"5","dim_payment","BookShop Transactional"
+```
+### Get Data Policy
+Retrieving a blueprint data policy works the same as with any other catalog. The table named 
+```shell
+pace get data-policy --catalog odd --database 3 --schema schema 14
+metadata:
+  description: BookShop Transactional
+  title: fct_sales
+source:
+  fields:
+  - name_parts:
+    - card_uuid
+    required: true
+    type: varchar
+  - name_parts:
+    - update_tmst
+...
+
+```


### PR DESCRIPTION
Before this change, interacting with OpendataDiscovery created a flat structure of 1 database/schema/table, so if you called `pace list databases --catalog odd` you'd get all tables in the catalog. This change adds a hierarchy.

```
pace list databases --catalog odd -o json | jq -r '.databases[]|[.id,.display_name,.type]|@csv'
"2","BookShop Data Lake","Data Lake"
"3","BookShop Transactional","Transactional"
"5","User Transactions","Messaging"
"7","KDS Clickstream","Messaging"
"8","Snowflake Sample Data","Samples"

pace list schemas --catalog odd --database 3 -o json | jq -r '.schemas[]|[.id,.name]|@csv'
"schema","BookShop Transactional"

pace list tables --catalog odd --database 3 --schema schema -o json | jq -r '.tables[]|[.id,.name,.schema.name]|@csv'
"15","dim_publishers","BookShop Transactional"
"14","fct_sales","BookShop Transactional"
"13","fct_inventory","BookShop Transactional"
"12","dim_currency","BookShop Transactional"
"11","dim_books","BookShop Transactional"
"10","dim_promo","BookShop Transactional"
"9","customer_tier_sbx","BookShop Transactional"
"8","dim_countries","BookShop Transactional"
"7","dim_cards","BookShop Transactional"
"6","dim_customer","BookShop Transactional"
"5","dim_payment","BookShop Transactional"

pace get data-policy --catalog odd --database 3 --schema schema 14
metadata:
  description: BookShop Transactional
  title: fct_sales
source:
  fields:
  - name_parts:
    - card_uuid
    required: true
    type: varchar
  - name_parts:
    - update_tmst
...

```