### PR TITLE
feat(pace-78): add spring kubernetes config support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,7 @@ val jooqMigrationDir = "$projectDir/src/main/resources/db/migration/postgresql"
 val jooqVersion = rootProject.ext["jooqVersion"] as String
 val kotestVersion = rootProject.ext["kotestVersion"] as String
 val openDataDiscoveryOpenApiDir = layout.buildDirectory.dir("generated/source/odd").get()
+val springCloudKubernetesVersion = rootProject.ext["springCloudKubernetesVersion"] as String
 project.version = if (gradle.startParameter.taskNames.any { it.lowercase() == "builddocker" }) {
     "${project.version}-SNAPSHOT"
 } else {
@@ -67,6 +68,8 @@ dependencies {
     implementation("com.databricks:databricks-sdk-java:0.13.0")
     implementation("com.github.drapostolos:type-parser:0.8.1")
     implementation("com.microsoft.sqlserver:mssql-jdbc:12.4.2.jre11")
+
+    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config:$springCloudKubernetesVersion")
 
     implementation("com.nimbusds:nimbus-jose-jwt:9.37.2")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.77")

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: pace
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/pace

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ schema=pace
 
 jooqVersion=3.18.7
 kotestVersion = 5.8.0
+springCloudKubernetesVersion=3.1.0
 
 dockertag = pace-local
 


### PR DESCRIPTION
This PR adds the `spring-cloud-starter-kubernetes-fabric8-config` starter which includes core Spring k8s awareness and support, as well as ConfigMap and Secret support. Docs to follow.