### PR TITLE
feat(pace-133): simplify data policy versioning in upsert call

### DIFF
--- a/app/src/main/kotlin/com/getstrm/pace/config/AppConfiguration.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/config/AppConfiguration.kt
@@ -22,5 +22,5 @@ data class CatalogConfiguration(
 )
 
 data class DataPoliciesConfiguration(
-    val autoIncrementVersion: Boolean = false,
+    val autoIncrementVersion: Boolean = true,
 )

--- a/app/src/main/kotlin/com/getstrm/pace/config/AppConfiguration.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/config/AppConfiguration.kt
@@ -8,6 +8,7 @@ data class AppConfiguration(
     val exposeApplicationExceptions: Boolean = false,
     val defaultViewSuffix: String = "",
     val catalogs: List<CatalogConfiguration> = emptyList(),
+    val dataPolicies: DataPoliciesConfiguration = DataPoliciesConfiguration(),
 )
 
 data class CatalogConfiguration(
@@ -18,4 +19,8 @@ data class CatalogConfiguration(
     val userName: String?,
     val password: String?,
     val fetchSize: Int? = 1,
+)
+
+data class DataPoliciesConfiguration(
+    val autoIncrementVersion: Boolean = false,
 )

--- a/app/src/main/kotlin/com/getstrm/pace/dao/DataPolicyDao.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/dao/DataPolicyDao.kt
@@ -4,8 +4,14 @@ import build.buf.gen.getstrm.pace.api.entities.v1alpha.DataPolicy
 import build.buf.gen.getstrm.pace.api.paging.v1alpha.PageParameters
 import com.getstrm.jooq.generated.tables.DataPolicies.Companion.DATA_POLICIES
 import com.getstrm.jooq.generated.tables.records.DataPoliciesRecord
+import com.getstrm.pace.config.AppConfiguration
 import com.getstrm.pace.exceptions.BadRequestException
-import com.getstrm.pace.util.*
+import com.getstrm.pace.util.PagedCollection
+import com.getstrm.pace.util.toApiDataPolicy
+import com.getstrm.pace.util.toJsonbWithDefaults
+import com.getstrm.pace.util.toOffsetDateTime
+import com.getstrm.pace.util.toTimestamp
+import com.getstrm.pace.util.withUnknownTotals
 import com.google.rpc.BadRequest
 import java.time.OffsetDateTime
 import org.jooq.DSLContext
@@ -15,6 +21,7 @@ import org.springframework.stereotype.Component
 @Component
 class DataPolicyDao(
     private val jooq: DSLContext,
+    private val appConfiguration: AppConfiguration,
 ) {
 
     fun listDataPolicies(pageParameters: PageParameters): PagedCollection<DataPoliciesRecord> =
@@ -97,8 +104,11 @@ class DataPolicyDao(
             .limit(1)
             .fetchOneInto(DATA_POLICIES)
 
-    private fun checkStaleness(existingVersion: Int, newVersion: Int) {
-        if (existingVersion != newVersion) {
+    private fun checkStaleness(existingVersion: Int, upsertedVersion: Int) {
+        if (
+            !appConfiguration.dataPolicies.autoIncrementVersion &&
+                existingVersion != upsertedVersion
+        ) {
             throw BadRequestException(
                 BadRequestException.Code.INVALID_ARGUMENT,
                 BadRequest.newBuilder()
@@ -107,12 +117,12 @@ class DataPolicyDao(
                             BadRequest.FieldViolation.newBuilder()
                                 .setField("metadata.version")
                                 .setDescription(
-                                    "DataPolicy version '$newVersion' is not the latest version '$existingVersion'. Please make sure your update is based on the latest version."
+                                    "DataPolicy version '$upsertedVersion' is not the latest version '$existingVersion'. Please make sure your update is based on the latest version.",
                                 )
-                                .build()
-                        )
+                                .build(),
+                        ),
                     )
-                    .build()
+                    .build(),
             )
         }
     }


### PR DESCRIPTION
Add following to your application configuration to revert to the previous behaviour where upon upsert, the latest version must be set in the data policy.

```
app:
  data-policies:
    auto-increment-version: false
```