### PR TITLE
fix(pace-162): validation checks fixed transform for type compatibility

### DIFF
--- a/app/src/main/kotlin/com/getstrm/pace/service/DataPolicyValidatorService.kt
+++ b/app/src/main/kotlin/com/getstrm/pace/service/DataPolicyValidatorService.kt
@@ -246,17 +246,13 @@ class DataPolicyValidatorService(
 
     private fun checkValidFixedValues(source: DataPolicy.Source, ruleSet: DataPolicy.RuleSet) {
         val fieldTypesMap = source.fieldsList.associateBy { it.pathStringUpper() }
-        val fixedTransformValuesMap =
-            ruleSet.fieldTransformsList
-                .map { fieldTransform ->
-                    fieldTypesMap[fieldTransform.field.pathStringUpper()]!! to
-                        fieldTransform.transformsList
-                            .filter { it.hasFixed() }
-                            .map { it.fixed.value }
-                }
-                .toMap()
+        val fixedTransformValues =
+            ruleSet.fieldTransformsList.map { fieldTransform ->
+                fieldTypesMap[fieldTransform.field.pathStringUpper()]!! to
+                    fieldTransform.transformsList.filter { it.hasFixed() }.map { it.fixed.value }
+            }
 
-        fixedTransformValuesMap.forEach { (field, fixedValues) ->
+        fixedTransformValues.forEach { (field, fixedValues) ->
             fixedValues.forEach { fixedValue ->
                 try {
                     jooq.select(DSL.cast(fixedValue, field.sqlDataType())).fetch()

--- a/app/src/test/kotlin/com/getstrm/pace/service/DataPolicyValidatorServiceTest.kt
+++ b/app/src/test/kotlin/com/getstrm/pace/service/DataPolicyValidatorServiceTest.kt
@@ -799,10 +799,7 @@ rule_sets:
           """
                 .toProto<DataPolicy>()
 
-        underTest.validate(
-            dataPolicy,
-            setOf("analytics", "marketing", "fraud-and-risk", "admin")
-        )
+        underTest.validate(dataPolicy, setOf("analytics", "marketing", "fraud-and-risk", "admin"))
     }
 }
 /*


### PR DESCRIPTION
Fixed Transforms have a string as value, that might be used in a string, but also boolean, double, int etc. context.

This change adds a type cast check to the data-policy validator.