### PR TITLE
feat: add h2 support for PACE db

### DIFF
--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -4,6 +4,8 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/pace
+  flyway:
+    locations: classpath:db/migration/{vendor}
 
 grpc:
   server:

--- a/server/src/main/resources/db/migration/h2/V1__create_policies_tables.sql
+++ b/server/src/main/resources/db/migration/h2/V1__create_policies_tables.sql
@@ -1,0 +1,15 @@
+create schema if not exists pace;
+
+create table if not exists pace.data_policies
+(
+    id          varchar                                not null,
+    platform_id varchar                                not null,
+    title       varchar                                not null,
+    description varchar,
+    version     int                                    not null,
+    created_at  timestamp with time zone default now() not null,
+    updated_at  timestamp with time zone default now() not null,
+    policy      json                                   not null,
+    active      boolean                  default false not null,
+    constraint data_policies_pk primary key (id, platform_id, version)
+);

--- a/server/src/main/resources/db/migration/h2/V2__create_global_transforms.sql
+++ b/server/src/main/resources/db/migration/h2/V2__create_global_transforms.sql
@@ -1,0 +1,13 @@
+create table if not exists pace.global_transforms
+(
+    -- is equal to the identifier of the oneof transform
+    -- can not freely chosen
+    ref            varchar                  not null,
+    -- defines the type of oneof transform
+    transform_type varchar                  not null,
+    created_at     timestamp with time zone not null,
+    updated_at     timestamp with time zone not null,
+    transform      json                     not null,
+    active         boolean                  not null,
+    constraint global_transforms_pk primary key (ref, transform_type)
+);


### PR DESCRIPTION
This PR makes it possible to run PACE with the in-memory H2 database as storage layer by simply using a configuration like:

```yaml
spring:
  datasource:
    url: jdbc:h2:mem:pace;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DATABASE_TO_LOWER=TRUE
    hikari:
      username: sa
      password: ""
      schema: public
    driver-class-name: org.h2.Driver
```